### PR TITLE
Added error codes for queries API

### DIFF
--- a/queries/app/queries/main.py
+++ b/queries/app/queries/main.py
@@ -1,15 +1,23 @@
 from uuid import UUID
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Response
 
 from .helper import existing_query, new_query
-from .schema import ConversationFull, Prompt, PromptPayload
+from .schema import APIError, ConversationFull, PromptPayload
 
 router = APIRouter()
 
 
 @router.post("/queries/{id:uuid}")
-async def send_prompt(id: UUID, prompt_body: PromptPayload):
-    if prompt_body.exist:
-        return await existing_query(id, prompt_body)
-    return await new_query(id, prompt_body)
+async def send_prompt(id: UUID, prompt_body: PromptPayload, response: Response):
+    try:
+        if prompt_body.exist:
+            if not await ConversationFull.find_one(ConversationFull.id == id):
+                return APIError(code=404, message="Specified resource(s) was not found")
+            result = await existing_query(id, prompt_body)
+            response.status_code = 201
+            return result
+        return await new_query(id, prompt_body)
+    except:
+        response.status_code = 422
+        return APIError(code=422, message="Unable to create resource")

--- a/queries/app/queries/schema.py
+++ b/queries/app/queries/schema.py
@@ -5,6 +5,21 @@ from beanie import Document
 from pydantic import BaseModel, Field
 
 
+class Description(BaseModel):
+    description: list[DescriptionParams] | None
+
+
+class APIError(BaseModel):
+    code: int = Field(description="API Error code associated with the error")
+    message: str = Field(description="Error message associated with the error")
+    request: Description | None = Field(
+        None, description="Request details associated with the error"
+    )
+    details: Description | None = Field(
+        None, description="Other details associated with the error"
+    )
+
+
 class Prompt(BaseModel):
     role: Literal["assistant", "user", "system", "function"] = Field(
         description="Query Role Type"
@@ -21,10 +36,6 @@ class DescriptionParams(BaseModel):
     completion_tokens: int
     prompt_tokens: int
     total_tokens: int
-
-
-class Description(BaseModel):
-    description: list[DescriptionParams] | None
 
 
 class Conversation(BaseModel):


### PR DESCRIPTION
Added error codes for queries API
Note: Most of the errors in parameters would be handled by pydantic before the API could run. Therefore, error code would be shown as 422 instead of the required 400